### PR TITLE
Fix bug in TradeDeal, fix bug in DeclineTrade, update badgepoints command, update item kit command

### DIFF
--- a/Protocols.External/[t] TradeHandler/[a] AcceptTrade.cs
+++ b/Protocols.External/[t] TradeHandler/[a] AcceptTrade.cs
@@ -12,9 +12,9 @@ public class AcceptTrade : ExternalProtocol
 
     public override void Run(string[] message)
     {
-        var traderModel = Player.TempData.TradeModel;
+        var originTradeModel = Player.TempData.TradeModel;
 
-        if (traderModel == null)
+        if (originTradeModel == null)
             return;
 
         var traderName = message[5];
@@ -23,16 +23,16 @@ public class AcceptTrade : ExternalProtocol
         if (tradedPlayer == null)
             return;
 
-        if (tradedPlayer != traderModel.TradingPlayer)
+        if (tradedPlayer != originTradeModel.TradingPlayer)
             return;
 
-        var tradeeModel = tradedPlayer.TempData.TradeModel;
+        var otherTradeModel = tradedPlayer.TempData.TradeModel;
 
-        if (tradeeModel == null)
+        if (otherTradeModel == null)
             return;
 
-        tradeeModel.AcceptedTrade = true;
-        traderModel.AcceptedTrade = true;
+        otherTradeModel.AcceptedTrade = true;
+        originTradeModel.AcceptedTrade = true;
 
         Player.SendXt("ta",
             tradedPlayer.CharacterName,

--- a/Protocols.External/[t] TradeHandler/[c] CancelTrade.cs
+++ b/Protocols.External/[t] TradeHandler/[c] CancelTrade.cs
@@ -2,15 +2,12 @@
 using Server.Reawakened.Network.Protocols;
 using Server.Reawakened.Players;
 using Server.Reawakened.Players.Extensions;
-using Server.Reawakened.Players.Helpers;
 
 namespace Protocols.External._t__TradeHandler;
 
 public class CancelTrade : ExternalProtocol
 {
     public override string ProtocolName => "tc";
-
-    public PlayerHandler PlayerHandler { get; set; }
 
     public override void Run(string[] message)
     {
@@ -21,8 +18,8 @@ public class CancelTrade : ExternalProtocol
 
         var tradingPlayer = tradeModel.TradingPlayer;
 
-        tradingPlayer?.SendXt("tc", Player.CharacterName);
-
         Player.RemoveTrade();
+
+        tradingPlayer?.SendXt("tc", Player.CharacterName);
     }
 }

--- a/Protocols.External/[t] TradeHandler/[e] PropositionRejected.cs
+++ b/Protocols.External/[t] TradeHandler/[e] PropositionRejected.cs
@@ -1,15 +1,12 @@
 ﻿using Server.Reawakened.Network.Extensions;
 using Server.Reawakened.Network.Protocols;
 using Server.Reawakened.Players;
-using Server.Reawakened.Players.Helpers;
 
 namespace Protocols.External._t__TradeHandler;
 
 public class PropositionRejected : ExternalProtocol
 {
     public override string ProtocolName => "te";
-
-    public PlayerHandler PlayerHandler { get; set; }
 
     public override void Run(string[] message)
     {
@@ -23,14 +20,13 @@ public class PropositionRejected : ExternalProtocol
         if (tradingPlayer == null)
             return;
 
-        var tradeeTradeModel = tradingPlayer.TempData.TradeModel;
+        var otherTradeModel = tradingPlayer.TempData.TradeModel;
 
-        if (tradeeTradeModel == null)
+        if (otherTradeModel == null)
             return;
 
-        playerTradeModel.ResetTrade();
-        tradeeTradeModel.ResetTrade();
+        otherTradeModel.ResetTrade();
 
-        tradingPlayer.SendXt("te", Player.CharacterName);
+        tradingPlayer?.SendXt("te", Player.CharacterName);
     }
 }

--- a/Protocols.External/[t] TradeHandler/[i] InviteToTrade.cs
+++ b/Protocols.External/[t] TradeHandler/[i] InviteToTrade.cs
@@ -25,6 +25,8 @@ public class InviteToTrade : ExternalProtocol
         Player.TempData.TradeModel = new TradeModel(invitedPlayer);
         invitedPlayer.TempData.TradeModel = new TradeModel(Player);
 
+        Player.TempData.TradeModel.InvitedPlayer = invitedPlayer;
+
         invitedPlayer?.SendXt("ti", Player.CharacterName);
     }
 }

--- a/Protocols.External/[t] TradeHandler/[o] PropositionCanceled.cs
+++ b/Protocols.External/[t] TradeHandler/[o] PropositionCanceled.cs
@@ -1,6 +1,5 @@
 ﻿using Server.Reawakened.Network.Extensions;
 using Server.Reawakened.Network.Protocols;
-using Server.Reawakened.Players.Helpers;
 
 namespace Protocols.External._t__TradeHandler;
 
@@ -8,21 +7,19 @@ public class PropositionCanceled : ExternalProtocol
 {
     public override string ProtocolName => "to";
 
-    public PlayerHandler PlayerHandler { get; set; }
-
     public override void Run(string[] message)
     {
-        var tradeModel = Player.TempData.TradeModel;
+        var playerTradeModel = Player.TempData.TradeModel;
 
-        if (tradeModel == null)
+        if (playerTradeModel == null)
             return;
 
-        var tradingPlayer = tradeModel.TradingPlayer;
+        var tradingPlayer = playerTradeModel.TradingPlayer;
 
         if (tradingPlayer == null)
             return;
 
-        tradeModel.ResetTrade();
+        playerTradeModel.ResetTrade();
 
         tradingPlayer?.SendXt("to", Player.CharacterName);
     }

--- a/Protocols.External/[t] TradeHandler/[p] ProposeItems.cs
+++ b/Protocols.External/[t] TradeHandler/[p] ProposeItems.cs
@@ -1,6 +1,5 @@
 ﻿using Server.Reawakened.Network.Extensions;
 using Server.Reawakened.Network.Protocols;
-using Server.Reawakened.Players.Helpers;
 using Server.Reawakened.Players.Models.Temporary;
 
 namespace Protocols.External._t__TradeHandler;
@@ -8,8 +7,6 @@ namespace Protocols.External._t__TradeHandler;
 public class ProposeItems : ExternalProtocol
 {
     public override string ProtocolName => "tp";
-
-    public PlayerHandler PlayerHandler { get; set; }
 
     public override void Run(string[] message)
     {
@@ -23,7 +20,6 @@ public class ProposeItems : ExternalProtocol
 
         tradeModel.ItemsInTrade = TradeModel.ReverseProposeItems(itemsProposed);
         tradeModel.BananasInTrade = bananas;
-        tradeModel.FinalisedTrade = true;
 
         tradeModel.TradingPlayer?.SendXt("tp", itemsProposed, bananas);
     }

--- a/Protocols.External/[t] TradeHandler/[r] DeclineTrade.cs
+++ b/Protocols.External/[t] TradeHandler/[r] DeclineTrade.cs
@@ -31,7 +31,7 @@ public class DeclineTrade : ExternalProtocol
         if (tradedPlayer != tradeModel.TradingPlayer)
             return;
 
-        var status = (DeclineType) int.Parse(message[6]);
+        var status = (DeclineType)int.Parse(message[6]);
 
         switch (status)
         {
@@ -39,7 +39,11 @@ public class DeclineTrade : ExternalProtocol
                 if (tradeModel.AcceptedTrade)
                     return;
 
-                tradedPlayer?.SendXt("tc", Player.CharacterName);
+                if (tradeModel.InvitedPlayer == tradedPlayer)
+                    tradedPlayer?.SendXt("tc", Player.CharacterName);
+
+                else
+                    tradedPlayer?.SendXt("tr", Player.CharacterName, (int)status);
                 break;
             case DeclineType.PlayerBusy or DeclineType.PlayerDnD:
                 tradedPlayer?.SendXt("tr", Player.CharacterName, (int)status);

--- a/Server.Reawakened/Chat/Services/ChatCommands.cs
+++ b/Server.Reawakened/Chat/Services/ChatCommands.cs
@@ -48,7 +48,7 @@ public class ChatCommands : IService
         AddCommand(new ChatCommand("changeName", "[first] [middle] [last]", ChangeName));
         AddCommand(new ChatCommand("unlockHotbar", "[petSlot 1 (true) / 0 (false)]", AddHotbar));
         AddCommand(new ChatCommand("giveItem", "[itemId] [amount]", AddItem));
-        AddCommand(new ChatCommand("badgePoints", "[amount]", BadgePoints));
+        AddCommand(new ChatCommand("badgePoints", "[badgePoints]", BadgePoints));
         AddCommand(new ChatCommand("levelUp", "[newLevel]", LevelUp));
         AddCommand(new ChatCommand("itemKit", "[itemKit]", ItemKit));
         AddCommand(new ChatCommand("cashKit", "[cashKit]", CashKit));
@@ -176,31 +176,7 @@ public class ChatCommands : IService
     
     private static bool BadgePoints(Player player, string[] args)
     {
-        var character = player.Character;
-
-        int amount;
-
-        if (args.Length < 2)
-        {
-            Log($"Please enter number of badge points", player);
-            return false;
-        }
-        if (!int.TryParse(args[1], out var pointsAmount) || args.Length < 2)
-            Log($"Invalid amount of badge points, defaulting to 1", player);
-
-        amount = pointsAmount;
-
-        if (amount <= 0)
-            amount = 1;
-
-        player.AddPoints(amount);
-
-        Log(
-            amount > 1
-                ? $"{character.Data.CharacterName} received {amount} badge points!"
-                : $"{character.Data.CharacterName} received {amount} badge point! (get grinding noob)", player
-           );
-
+        player.AddPoints();
         return true;
     }
 

--- a/Server.Reawakened/Configs/ServerRConfig.cs
+++ b/Server.Reawakened/Configs/ServerRConfig.cs
@@ -97,33 +97,37 @@ public class ServerRConfig : IRConfig
 
         SingleItemKit =
         [
-            394, // glider
-            395, // grappling hook
-            397, // wooden slingshot
-            453, // kernel blaster
+            394,  // glider
+            395,  // grappling hook
+            393,  // snowboard
+            397,  // wooden slingshot
+            423,  // golden slingshot
+            453,  // kernel blaster
+            1009, // snake staff
+            584,  // scrying orb
             2978, // wooden sword
-            2883, // oak helmet
-            2886, // oak armor
-            2880, // oak pants
-            1232, // burglar mask
-            3152, // super monkey
-            3053, // boom bomb
-            3023, // warrior costume
-            3022, // boom bug
-            2972, // ace pilot
-            2973, // crimson dragon
+            2883, // oak plank helmet
+            2886, // oak plank armor
+            2880, // oak plank pants
+            1232, // black cat burglar mask
+            3152, // super monkey pack
+            3053, // boom bomb construction kit
+            3023, // ladybug warrior costume pack
+            3022, // boom bug pack
+            2972, // ace pilot pack
+            2973, // crimson dragon pack
             2923, // banana box
         ];
 
         StackedItemKit =
         [
-            396, // healing staff
-            585, // invisible bomb
+            396,  // healing staff
+            585,  // invisible bomb
             1568, // red apple
-            1704, // healing potion
+            405,  // healing potion
         ];
 
-        AmountToStack = 98;
+        AmountToStack = 99;
         CashKitAmount = 100000;
 
         KickAfterTime = TimeSpan.FromMinutes(5).TotalMilliseconds;

--- a/Server.Reawakened/Players/Extensions/PlayerExtensions.cs
+++ b/Server.Reawakened/Players/Extensions/PlayerExtensions.cs
@@ -4,6 +4,7 @@ using Server.Reawakened.Network.Extensions;
 using Server.Reawakened.Players.Helpers;
 using Server.Reawakened.Players.Models;
 using Server.Reawakened.Players.Models.Character;
+using Server.Reawakened.Players.Models.Protocol;
 using Server.Reawakened.Rooms.Extensions;
 using Server.Reawakened.Rooms.Services;
 using Server.Reawakened.XMLs.Bundles;
@@ -92,12 +93,12 @@ public static class PlayerExtensions
         if (player.TempData.TradeModel == null)
             return;
 
-        var tradee = player.TempData.TradeModel.TradingPlayer;
+        var trade = player.TempData.TradeModel.TradingPlayer;
 
         player.TempData.TradeModel = null;
 
-        if (tradee != null)
-            tradee.TempData.TradeModel = null;
+        if (trade != null)
+            trade.TempData.TradeModel = null;
     }
 
     public static void AddBananas(this Player player, int collectedBananas)
@@ -128,23 +129,20 @@ public static class PlayerExtensions
         player.SendCashUpdate();
     }
 
-    public static void AddPoints(this Player player, int abilityPoints)
+    public static void AddPoints(this Player player)
     {
         var charData = player.Character.Data;
-        charData.BadgePoints += abilityPoints;
-        player.SendPointsUpdate();
+
+        charData.BadgePoints = 0;
+        charData.BadgePoints += 100;
+
+        player.SendLevelUp();
     }
 
     public static void SendCashUpdate(this Player player)
     {
         var charData = player.Character.Data;
         player.SendXt("ca", charData.Cash, charData.NCash);
-    }
-
-    public static void SendPointsUpdate(this Player player)
-    {
-        var charData = player.Character.Data;
-        player.SendXt("ca", charData.BadgePoints);
     }
 
     public static void SendLevelChange(this Player player, WorldHandler worldHandler, WorldGraphXML worldGraph)

--- a/Server.Reawakened/Players/Models/Trade/TradeModel.cs
+++ b/Server.Reawakened/Players/Models/Trade/TradeModel.cs
@@ -6,6 +6,8 @@ public class TradeModel(Player tradingPlayer)
 {
     public Player TradingPlayer => tradingPlayer;
 
+    public Player InvitedPlayer { get; set; }
+
     public Dictionary<int, int> ItemsInTrade { get; set; } = [];
     public int BananasInTrade { get; set; } = 0;
     public bool FinalisedTrade { get; set; } = false;

--- a/Server.Reawakened/Rooms/Extensions/PlayerExtensions.cs
+++ b/Server.Reawakened/Rooms/Extensions/PlayerExtensions.cs
@@ -68,7 +68,8 @@ public static class PlayerExtensions
     {
         var levelUpData = new LevelUpDataModel
         {
-            Level = player.Character.Data.GlobalLevel
+            Level = player.Character.Data.GlobalLevel,
+            IncPowerJewel = player.Character.Data.BadgePoints
         };
 
         foreach (var currentPlayer in player.Room.Players.Values)


### PR DESCRIPTION
Fixed a bug that caused a trade to complete for both players after only 1 player accepts the trade. Fixed a bug that sent the cancel trade protocol when it was supposed to send decline trade. Updated badgepoints command, still a bit wonky but at least updates points in game instead of on restart. Updated item kit.