### PR TITLE
Add a Discord Chat Bot

### DIFF
--- a/Protocols.External/[a] ChatHandler/[e] FreeChat.cs
+++ b/Protocols.External/[a] ChatHandler/[e] FreeChat.cs
@@ -1,6 +1,7 @@
 ﻿using A2m.Server;
 using Microsoft.Extensions.Logging;
 using Server.Reawakened.Core.Configs;
+using Server.Reawakened.Core.Services;
 using Server.Reawakened.Network.Extensions;
 using Server.Reawakened.Network.Protocols;
 using Server.Reawakened.Players;
@@ -13,7 +14,8 @@ public class FreeChat : ExternalProtocol
 
     public ILogger<FreeChat> Logger { get; set; }
     public ServerRConfig Config { get; set; }
-
+    public DiscordHandler DiscordHandler { get; set; }
+    
     public override void Run(string[] message)
     {
         var channelType = (CannedChatChannel)Convert.ToInt32(message[5]);
@@ -24,6 +26,9 @@ public class FreeChat : ExternalProtocol
         {
             var character = Player.Character;
             Player.Room.Chat(channelType, character.Data.CharacterName, chatMessage);
+
+            // Sends a chat message to Discord
+            DiscordHandler.SendMessage(character.Data.CharacterName, chatMessage);
         }
         else if (channelType == CannedChatChannel.Group)
         {

--- a/Server.Reawakened/Chat/Commands/Item/AddItem.cs
+++ b/Server.Reawakened/Chat/Commands/Item/AddItem.cs
@@ -12,13 +12,16 @@ public class AddItem : SlashCommand
 
     public override string CommandDescription => "Adds an item using it's prefab name.";
 
-    public override List<ParameterModel> Parameters => [
-        new ParameterModel() {
+    public override List<ParameterModel> Parameters => 
+    [
+        new ParameterModel() 
+        {
             Name = "name",
             Description = "The prefab name of the item to be added.",
             Optional = false
         },
-        new ParameterModel() {
+        new ParameterModel() 
+        {
             Name = "amount",
             Description = "The amount of the item to give or default to 1.",
             Optional = true

--- a/Server.Reawakened/Chat/Commands/Item/AllIngredients.cs
+++ b/Server.Reawakened/Chat/Commands/Item/AllIngredients.cs
@@ -13,8 +13,10 @@ public class AllIngredients : SlashCommand
 
     public override string CommandDescription => "Adds all crafting ingredients and recipes.";
 
-    public override List<ParameterModel> Parameters => [
-        new ParameterModel() {
+    public override List<ParameterModel> Parameters => 
+    [
+        new ParameterModel() 
+        {
             Name = "amount",
             Description = "The amount of the item to give or default to 1.",
             Optional = true

--- a/Server.Reawakened/Chat/Commands/Item/ItemKit.cs
+++ b/Server.Reawakened/Chat/Commands/Item/ItemKit.cs
@@ -14,8 +14,10 @@ public class ItemKit : SlashCommand
 
     public override string CommandDescription => "This will give an item kit.";
 
-    public override List<ParameterModel> Parameters => [
-        new ParameterModel() {
+    public override List<ParameterModel> Parameters => 
+    [
+        new ParameterModel() 
+        {
             Name = "amount",
             Description = "The amount of the kit to give.",
             Optional = true

--- a/Server.Reawakened/Chat/Commands/Misc/Bananas.cs
+++ b/Server.Reawakened/Chat/Commands/Misc/Bananas.cs
@@ -14,8 +14,10 @@ public class Bananas : SlashCommand
 
     public override string CommandDescription => "Adds bananas or default to cash kit amount.";
 
-    public override List<ParameterModel> Parameters => [
-        new ParameterModel() {
+    public override List<ParameterModel> Parameters => 
+    [
+        new ParameterModel() 
+        {
             Name = "amount",
             Description = "The amount of bananas to receive.",
             Optional = true

--- a/Server.Reawakened/Chat/Commands/Misc/ChangeName.cs
+++ b/Server.Reawakened/Chat/Commands/Misc/ChangeName.cs
@@ -12,18 +12,22 @@ public partial class ChangeName : SlashCommand
 
     public override string CommandDescription => "Change your monkey's name.";
 
-    public override List<ParameterModel> Parameters => [
-        new ParameterModel() {
+    public override List<ParameterModel> Parameters => 
+    [
+        new ParameterModel() 
+        {
             Name = "firstName",
             Description = "The monkey's first name.",
             Optional = false
         },
-        new ParameterModel() {
+        new ParameterModel() 
+        {
             Name = "middleName",
             Description = "The monkey's middle name",
             Optional = false
         },
-        new ParameterModel() {
+        new ParameterModel() 
+        {
             Name = "lastName",
             Description = "The monkey's last name",
             Optional = true

--- a/Server.Reawakened/Chat/Commands/Misc/LevelUp.cs
+++ b/Server.Reawakened/Chat/Commands/Misc/LevelUp.cs
@@ -13,8 +13,10 @@ public class LevelUp : SlashCommand
 
     public override string CommandDescription => "Level up to a specified level or default to max level.";
 
-    public override List<ParameterModel> Parameters => [
-        new ParameterModel() {
+    public override List<ParameterModel> Parameters => 
+    [
+        new ParameterModel() 
+        {
             Name = "level",
             Description = "Levels the user up to the specified level.",
             Optional = true

--- a/Server.Reawakened/Chat/Commands/Misc/PlayerCount.cs
+++ b/Server.Reawakened/Chat/Commands/Misc/PlayerCount.cs
@@ -10,8 +10,10 @@ public class PlayerCount : SlashCommand
 
     public override string CommandDescription => "Check how many player's there are currently.";
 
-    public override List<ParameterModel> Parameters => [
-        new ParameterModel() {
+    public override List<ParameterModel> Parameters => 
+    [
+        new ParameterModel() 
+        {
             Name = "detailed",
             Description = "Use true to see all player locations.",
             Optional = true

--- a/Server.Reawakened/Chat/Commands/Misc/SetAccess.cs
+++ b/Server.Reawakened/Chat/Commands/Misc/SetAccess.cs
@@ -11,25 +11,31 @@ public class SetAccess : SlashCommand
 
     public override string CommandDescription => "Allows you to set a player's access level. (Owner only)";
 
-    public override List<ParameterModel> Parameters => [
-        new ParameterModel() {
+    public override List<ParameterModel> Parameters => 
+    [
+        new ParameterModel() 
+        {
             Name = "number",
             Description = "The access level.",
             Optional = true,
             Options = [
-                new OptionModel() {
+                new OptionModel() 
+                {
                     Name = "0",
                     Description = "The Player access level.",
                 },
-                new OptionModel() {
+                new OptionModel() 
+                {
                     Name = "1",
                     Description = "The VIP access level."
                 },
-                new OptionModel() {
+                new OptionModel() 
+                {
                     Name = "2",
                     Description = "The Moderator access level."
                 },
-                new OptionModel() {
+                new OptionModel() 
+                {
                     Name = "3",
                     Description = "The Owner access level."
                 }

--- a/Server.Reawakened/Chat/Commands/Misc/SetEwSubscribed.cs
+++ b/Server.Reawakened/Chat/Commands/Misc/SetEwSubscribed.cs
@@ -11,8 +11,10 @@ public class SetEwSubscribed : SlashCommand
 
     public override string CommandDescription => "Change membership status.";
 
-    public override List<ParameterModel> Parameters => [
-        new ParameterModel() {
+    public override List<ParameterModel> Parameters => 
+    [
+        new ParameterModel() 
+        {
             Name = "status",
             Description = "A number 0/1 for membership status.",
             Optional = false

--- a/Server.Reawakened/Chat/Commands/Quest/AddQuest.cs
+++ b/Server.Reawakened/Chat/Commands/Quest/AddQuest.cs
@@ -15,8 +15,10 @@ public class AddQuest : SlashCommand
 
     public override string CommandDescription => "Add the provided quest by id.";
 
-    public override List<ParameterModel> Parameters => [
-        new ParameterModel() {
+    public override List<ParameterModel> Parameters => 
+    [
+        new ParameterModel() 
+        {
             Name = "id",
             Description = "The provided quest id.",
             Optional = false

--- a/Server.Reawakened/Chat/Commands/Quest/CompleteQuest.cs
+++ b/Server.Reawakened/Chat/Commands/Quest/CompleteQuest.cs
@@ -11,8 +11,10 @@ public class CompleteQuest : SlashCommand
 
     public override string CommandDescription => "This marks the provided quest as completed.";
 
-    public override List<ParameterModel> Parameters => [
-        new ParameterModel() {
+    public override List<ParameterModel> Parameters => 
+    [
+        new ParameterModel() 
+        {
             Name = "name",
             Description = "The quest name to be marked as completed. (i.e. OOTU_0_07)",
             Optional = false

--- a/Server.Reawakened/Chat/Commands/Quest/CompleteQuestObjectives.cs
+++ b/Server.Reawakened/Chat/Commands/Quest/CompleteQuestObjectives.cs
@@ -12,8 +12,10 @@ public class CompleteQuestObjectives : SlashCommand
 
     public override string CommandDescription => "Completes the provided quest's objectives.";
 
-    public override List<ParameterModel> Parameters => [
-        new ParameterModel() {
+    public override List<ParameterModel> Parameters => 
+    [
+        new ParameterModel() 
+        {
             Name = "name",
             Description = "The quest to have it's objectives marked as completed. (i.e. OOTU_0_07)",
             Optional = false

--- a/Server.Reawakened/Chat/Commands/Quest/FindQuest.cs
+++ b/Server.Reawakened/Chat/Commands/Quest/FindQuest.cs
@@ -11,7 +11,15 @@ public class FindQuest : SlashCommand
 
     public override string CommandDescription => "Allows you to find a quest name.";
 
-    public override List<ParameterModel> Parameters => [];
+    public override List<ParameterModel> Parameters => 
+    [
+        new ParameterModel() 
+        {
+            Name = "questName",
+            Description = "The quest to find.",
+            Optional = false
+        }
+    ];
 
     public override AccessLevel AccessLevel => AccessLevel.Player;
 

--- a/Server.Reawakened/Chat/Commands/World/ChangeLevel.cs
+++ b/Server.Reawakened/Chat/Commands/World/ChangeLevel.cs
@@ -13,8 +13,10 @@ public class ChangeLevel : SlashCommand
 
     public override string CommandDescription => "Allows you to warp to a new level.";
 
-    public override List<ParameterModel> Parameters => [
-        new ParameterModel() {
+    public override List<ParameterModel> Parameters => 
+    [
+        new ParameterModel() 
+        {
             Name = "levelName",
             Description = "The level name to warp to.",
             Optional = false

--- a/Server.Reawakened/Chat/Commands/World/Warp.cs
+++ b/Server.Reawakened/Chat/Commands/World/Warp.cs
@@ -13,8 +13,10 @@ public class Warp : SlashCommand
 
     public override string CommandDescription => "Change's your level to the specified level id.";
 
-    public override List<ParameterModel> Parameters => [
-        new ParameterModel() {
+    public override List<ParameterModel> Parameters => 
+    [
+        new ParameterModel() 
+        {
             Name = "levelId",
             Description = "The level id.",
             Optional = false

--- a/Server.Reawakened/Core/Configs/DiscordRwConfig.cs
+++ b/Server.Reawakened/Core/Configs/DiscordRwConfig.cs
@@ -1,0 +1,14 @@
+﻿using Server.Base.Core.Abstractions;
+
+namespace Server.Reawakened.Core.Configs;
+public class DiscordRwConfig : IRwConfig
+{
+    public string DiscordBotToken { get; set; }
+    public ulong ChannelId { get; set; }
+
+    public DiscordRwConfig()
+    {
+        DiscordBotToken = string.Empty;
+        ChannelId = 0;
+    }
+}

--- a/Server.Reawakened/Core/Configs/ServerRConfig.cs
+++ b/Server.Reawakened/Core/Configs/ServerRConfig.cs
@@ -36,9 +36,6 @@ public class ServerRConfig : IRConfig
 
     public string[] DefaultProtocolTypeIgnore { get; }
 
-    public char ChatCommandStart { get; }
-    public int ChatCommandPadding { get; }
-
     public double RoomTickRate { get; }
 
     public int LogOnLagCount { get; }
@@ -104,9 +101,6 @@ public class ServerRConfig : IRConfig
 
         LogSyncState = false;
         DefaultProtocolTypeIgnore = ["ss", "Pp", "ku", "kr"];
-
-        ChatCommandStart = '.';
-        ChatCommandPadding = 8;
 
         LogOnLagCount = 200;
 

--- a/Server.Reawakened/Core/Configs/ServerRwConfig.cs
+++ b/Server.Reawakened/Core/Configs/ServerRwConfig.cs
@@ -7,11 +7,15 @@ public class ServerRwConfig : IRwConfig
     public string CurrentEventOverride { get; set; }
     public string CurrentTimedEventOverride { get; set; }
     public string DomainName { get; set; }
+    public string DiscordBotToken { get; set; }
+    public ulong ChannelId { get; set; }
 
     public ServerRwConfig()
     {
         CurrentEventOverride = string.Empty;
         CurrentTimedEventOverride = string.Empty;
         DomainName = string.Empty;
+        DiscordBotToken = string.Empty;
+        ChannelId = 0;
     }
 }

--- a/Server.Reawakened/Core/Configs/ServerRwConfig.cs
+++ b/Server.Reawakened/Core/Configs/ServerRwConfig.cs
@@ -7,15 +7,11 @@ public class ServerRwConfig : IRwConfig
     public string CurrentEventOverride { get; set; }
     public string CurrentTimedEventOverride { get; set; }
     public string DomainName { get; set; }
-    public string DiscordBotToken { get; set; }
-    public ulong ChannelId { get; set; }
 
     public ServerRwConfig()
     {
         CurrentEventOverride = string.Empty;
         CurrentTimedEventOverride = string.Empty;
         DomainName = string.Empty;
-        DiscordBotToken = string.Empty;
-        ChannelId = 0;
     }
 }

--- a/Server.Reawakened/Core/Services/DiscordHandler.cs
+++ b/Server.Reawakened/Core/Services/DiscordHandler.cs
@@ -1,0 +1,73 @@
+﻿using A2m.Server;
+using Discord;
+using Discord.WebSocket;
+using Server.Base.Core.Abstractions;
+using Server.Reawakened.Core.Configs;
+using Server.Reawakened.Network.Extensions;
+using Server.Reawakened.Players.Helpers;
+
+namespace Server.Reawakened.Core.Services;
+public class DiscordHandler(ServerRwConfig rwConfig, PlayerContainer playerContainer) : IService
+{
+    private DiscordSocketClient socketClient;
+
+    private string botToken;
+    private ulong channelId;
+
+    public void Initialize()
+    {
+        botToken = rwConfig.DiscordBotToken;
+        channelId = rwConfig.ChannelId;
+
+        if (string.IsNullOrEmpty(botToken))
+            return;
+
+        socketClient = new DiscordSocketClient();
+        socketClient.MessageReceived += ClientOnMessageReceived;
+
+        socketClient.LoginAsync(TokenType.Bot, botToken);
+        socketClient.StartAsync();
+    }
+
+    public void SendMessage(string author, string message)
+    {
+        if (socketClient == null || string.IsNullOrEmpty(botToken))
+            return;
+
+        var socketChannel = (ISocketMessageChannel)socketClient.GetChannel(channelId);
+
+        socketChannel.SendMessageAsync(author + ": " + message);
+    }
+
+    private async Task ClientOnMessageReceived(SocketMessage socketMessage) =>
+        await Task.Run(() =>
+        {
+            if (!socketMessage.Author.IsBot)
+            {
+                var author = socketMessage.Author.Username;
+                var channelId = socketMessage.Channel.Id;
+                var socketChannel = (ISocketMessageChannel)socketClient.GetChannel(channelId);
+
+                var messageId = socketMessage.Id;
+                var message = socketChannel.GetMessageAsync(messageId);
+
+                if (this.channelId != socketChannel.Id)
+                    return;
+
+                Log(message.Result.Content, author);
+            }
+        });
+
+    private void Log(string message, string author)
+    {
+        lock (PlayerContainer.Lock)
+        {
+            foreach (
+                var client in
+                from client in playerContainer.GetAllPlayers()
+                select client
+            )
+                client.Chat(CannedChatChannel.Speak, "Discord > " + author, message);
+        }
+    }
+}

--- a/Server.Reawakened/Core/Services/DiscordHandler.cs
+++ b/Server.Reawakened/Core/Services/DiscordHandler.cs
@@ -7,7 +7,7 @@ using Server.Reawakened.Network.Extensions;
 using Server.Reawakened.Players.Helpers;
 
 namespace Server.Reawakened.Core.Services;
-public class DiscordHandler(ServerRwConfig rwConfig, PlayerContainer playerContainer) : IService
+public class DiscordHandler(DiscordRwConfig rwConfig, PlayerContainer playerContainer) : IService
 {
     private DiscordSocketClient socketClient;
 

--- a/Server.Reawakened/Core/Services/DiscordHandler.cs
+++ b/Server.Reawakened/Core/Services/DiscordHandler.cs
@@ -67,7 +67,7 @@ public class DiscordHandler(DiscordRwConfig rwConfig, PlayerContainer playerCont
                 from client in playerContainer.GetAllPlayers()
                 select client
             )
-                client.Chat(CannedChatChannel.Speak, "Discord > " + author, message);
+                client.Chat(CannedChatChannel.Tell, "Discord > " + author, message);
         }
     }
 }

--- a/Server.Reawakened/Server.Reawakened.csproj
+++ b/Server.Reawakened/Server.Reawakened.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <ProjectReference Include="..\Server.Base\Server.Base.csproj" />
         <ProjectReference Include="..\Server.Web\Server.Web.csproj" />
-
+        <PackageReference Include="Discord.Net.WebSocket" Version="3.15.0" />
         <PackageReference Include="ShellProgressBar" Version="5.2.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Changes:
- Added Discord.Net.WebSocket package to Server.Reawakened
- Created a DiscordHandler service in Server.Reawakened.Core.Services
- Created a new config for the Discord Bot (DiscordRwConfig)
- Setup to listen to a specific channel on discord/in-game (public chat for any trail/level) then send that message to either in-game or discord
- Updated slash commands parameter formatting and added a few missing parameters

I have made this optional it will be disabled by default

The bot only requires read/view channels and send/read messages permissions to function

like this
![](https://cdn.discordapp.com/attachments/1039424942502056012/1252108295695503420/image.png?ex=6671acf8&is=66705b78&hm=94c34b8a5aeed4350b81183f239387872c25c3419f9ae670130bc51cf032a5da&)
![](https://cdn.discordapp.com/attachments/1039424942502056012/1252108295976648774/image.png?ex=6671acf8&is=66705b78&hm=b8714e7746a63e49ad3c7d3b589e5d5171ab2a0cf0fa91af25a8f898cbf07b22&)