### PR TITLE
Add ItemEffect to EditItem + Bugfixes

### DIFF
--- a/Server.Reawakened/Assets/LocalAssets/EditItem.xml
+++ b/Server.Reawakened/Assets/LocalAssets/EditItem.xml
@@ -434,6 +434,9 @@
         <Item name="WPN_PRJ_XmasSlingshot01">
             <EditAttribute key="descriptionId" value="1000578"/>
         </Item>
+        <Item name="Add_COM_KidBoy01_S02">
+            <EditAttribute key="descriptionId" value="1000578"/>
+        </Item>
     </GameVersion>
     <GameVersion version="vMinigames2012">
     </GameVersion>
@@ -453,8 +456,18 @@
         <Item name="WPN_1H_SwordKnight01">
             <EditAttribute key="id" value="3351"/>
         </Item>
+        <Item name="COL_POT_Healing01">
+            <EditItemEffects>
+                <ItemEffect duration="0" type="Healing" value="900"/>
+            </EditItemEffects>
+        </Item>
     </GameVersion>
     <GameVersion version="v2011">
+        <Item name="Col_POT_ExperiencePotion01">
+            <EditItemEffects>
+                <ItemEffect duration="3600" type="ExperienceMultiplier" value="110"/>
+            </EditItemEffects>
+        </Item>
     </GameVersion>
     <GameVersion version="Unknown">
     </GameVersion>

--- a/Server.Reawakened/Assets/LocalAssets/EditItem.xml
+++ b/Server.Reawakened/Assets/LocalAssets/EditItem.xml
@@ -461,11 +461,46 @@
                 <ItemEffect duration="0" type="Healing" value="900"/>
             </EditItemEffects>
         </Item>
+        <Item name="COL_POT_Healing02">
+            <EditItemEffects>
+                <ItemEffect duration="0" type="Healing" value="1900"/>
+            </EditItemEffects>
+        </Item>
+        <Item name="COL_POT_Healing03">
+            <EditItemEffects>
+                <ItemEffect duration="0" type="Healing" value="4000"/>
+            </EditItemEffects>
+        </Item>
+        <Item name="COL_POT_Healing04">
+            <EditItemEffects>
+                <ItemEffect duration="0" type="Healing" value="6000"/>
+            </EditItemEffects>
+        </Item>
+        <Item name="COL_POT_Healing05">
+            <EditItemEffects>
+                <ItemEffect duration="0" type="Healing" value="8100"/>
+            </EditItemEffects>
+        </Item>
+        <Item name="COL_POT_Healing06">
+            <EditItemEffects>
+                <ItemEffect duration="0" type="Healing" value="10200"/>
+            </EditItemEffects>
+        </Item>
     </GameVersion>
     <GameVersion version="v2011">
-        <Item name="Col_POT_ExperiencePotion01">
+        <Item name="COL_POT_BananaPotion01">
+            <EditItemEffects>
+                <ItemEffect duration="3600" type="BananaMultiplier" value="110"/>
+            </EditItemEffects>
+        </Item>
+        <Item name="COL_POT_ExperiencePotion01">
             <EditItemEffects>
                 <ItemEffect duration="3600" type="ExperienceMultiplier" value="110"/>
+            </EditItemEffects>
+        </Item>
+        <Item name="COL_POT_ExperiencePotion02">
+            <EditItemEffects>
+                <ItemEffect duration="7200" type="ExperienceMultiplier" value="110"/>
             </EditItemEffects>
         </Item>
     </GameVersion>

--- a/Server.Reawakened/Entities/Components/Characters/Controllers/Base/Abstractions/BaseAIRetreatState.cs
+++ b/Server.Reawakened/Entities/Components/Characters/Controllers/Base/Abstractions/BaseAIRetreatState.cs
@@ -22,6 +22,6 @@ public abstract class BaseAIRetreatState<T> : BaseAIState<T>
             return;
 
         foreach (var trigReceiver in Room.GetEntitiesFromId<TriggerReceiverComp>(DoorId.ToString()))
-            trigReceiver.Trigger(true);
+            trigReceiver.Trigger(true, Id);
     }
 }

--- a/Server.Reawakened/Entities/Components/GameObjects/Hazards/Abstractions/BaseHazardControllerComp.cs
+++ b/Server.Reawakened/Entities/Components/GameObjects/Hazards/Abstractions/BaseHazardControllerComp.cs
@@ -156,21 +156,23 @@ public abstract class BaseHazardControllerComp<T> : Component<T> where T : Hazar
 
         Damage = (int)Math.Ceiling(player.Character.MaxLife * HealthRatioDamage);
 
+        var enemy = Room.GetEnemy(_id);
+        if (enemy != null)
+            Damage = WorldStatistics.GetValue(ItemEffectType.AbilityPower, WorldStatisticsGroup.Enemy, enemy.Level) -
+                     player.Character.CalculateDefense(EffectType, ItemCatalog);
+
         Logger.LogTrace("Applying {statusEffect} to {characterName} from {prefabName}", EffectType, player.CharacterName, PrefabName);
 
         switch (EffectType)
         {
-            case ItemEffectType.Unknown:
-                return;
+            // Some hazards actually use Unknown, so don't discern by this one
+            //case ItemEffectType.Unknown:
+            //    return;
             case ItemEffectType.SlowStatusEffect:
                 ApplySlowEffect(player);
                 break;
             case ItemEffectType.BluntDamage:
-                var enemy = Room.GetEnemy(Id);
-                var damage = (float)WorldStatistics.GetValue(ItemEffectType.AbilityPower, WorldStatisticsGroup.Enemy, enemy.Level) -
-                             player.Character.CalculateDefense(EffectType, ItemCatalog);
-
-                player.ApplyCharacterDamage((int)damage, Id, DamageDelay, ServerRConfig, TimerThread);
+                player.ApplyCharacterDamage(Damage, _id, DamageDelay, ServerRConfig, TimerThread);
                 break;
             case ItemEffectType.PoisonDamage:
                 TimerThread.DelayCall(ApplyPoisonEffect, player,

--- a/Server.Reawakened/Entities/Components/GameObjects/Trigger/Abstractions/BaseTriggerCoopController.cs
+++ b/Server.Reawakened/Entities/Components/GameObjects/Trigger/Abstractions/BaseTriggerCoopController.cs
@@ -250,7 +250,10 @@ public abstract class BaseTriggerCoopController<T> : Component<T>, ITriggerComp,
         {
             if (player.Character.Pets.TryGetValue(player.GetEquippedPetId(ServerRConfig), out var pet) && !pet.InCoopState() &&
                 InteractType == InteractionType.PetChain || InteractType == InteractionType.PetSwitch)
-                pet.CurrentTriggerId = Id;
+            {
+                if (pet != null)
+                    pet.CurrentTriggerId = Id;
+            }
 
             if (!string.IsNullOrEmpty(QuestCompletedRequired))
             {

--- a/Server.Reawakened/Entities/Enemies/EnemyTypes/Abstractions/BaseEnemy.cs
+++ b/Server.Reawakened/Entities/Enemies/EnemyTypes/Abstractions/BaseEnemy.cs
@@ -214,7 +214,7 @@ public abstract class BaseEnemy : IDestructible
     {
         if (OnDeathTargetId is not null and not "0")
             foreach (var trigger in Room.GetEntitiesFromId<TriggerReceiverComp>(OnDeathTargetId))
-                trigger.Trigger(true);
+                trigger.Trigger(true, Id);
 
         SendRewards(player);
 

--- a/Server.Reawakened/Players/Extensions/PlayerHealExtensions.cs
+++ b/Server.Reawakened/Players/Extensions/PlayerHealExtensions.cs
@@ -42,8 +42,6 @@ public static class PlayerHealExtensions
             usedItem.ItemEffects.FirstOrDefault().Value :
             usedItem.ItemEffects.LastOrDefault().Value;
 
-        healValue = GetBuffedHealValue(player, healValue);
-
         //If healing staff, convert heal value.
         if (usedItem.InventoryCategoryID == ItemFilterCategory.WeaponAndAbilities)
             healValue = GetHealValue(player, Convert.ToInt32(player.Character.MaxLife / config.HealingStaffHealValue));
@@ -104,23 +102,11 @@ public static class PlayerHealExtensions
             player.Character.CurrentLife <= 0)
             return;
 
-        tickHealValue = GetBuffedHealValue(player, tickHealValue);
-
         var healEvent = new Health_SyncEvent(player.GameObjectId.ToString(), player.Room.Time,
            player.Character.Write.CurrentLife += tickHealValue, player.Character.MaxLife, string.Empty);
 
         player.Room.SendSyncEvent(healEvent);
     }
-
-    //Original healing value >2011.
-    private static int GetBuffedHealValue(Player player, int outOfDateHealValue)
-    {
-        var healValue = outOfDateHealValue * 18;
-
-        return GetHealValue(player, healValue);
-    }
-    //(This is really needed in the games current state or else healing items aren't worth buying or using)
-    //Worth noting; Item descriptions in-game display 2011 stats because items load from an out of date ItemCatalogDict, instead of MiscTextDisc.
 
     private static int GetHealValue(Player player, int healValue)
     {

--- a/Server.Reawakened/XMLs/Data/Enemy/Models/ItemEffectModel.cs
+++ b/Server.Reawakened/XMLs/Data/Enemy/Models/ItemEffectModel.cs
@@ -1,0 +1,6 @@
+﻿public class ItemEffectNodeModel(string duration, string type, string value)
+{
+    public string Duration = duration;
+    public string Type = type;
+    public string Value = value;
+}


### PR DESCRIPTION
- Fixed crash when pushing a button without a pet equipped
- Fixed crash upon taking Blunt type damage from enemy
- Fixed issue where Unknown damage type was unhandled
- Enemies now apply the correct amount of damage on contact
- Added ItemEffect modification support to EditItem
- Corrected healing values of all Healing Potions
- Corrected values of Elixirs of Wisdom and Elixirs of Wealth