### PR TITLE
ReportBug protocol and early 2012 fixes

### DIFF
--- a/Protocols.External/[o] ReportMessageHandler/[a] ReportAbuse.cs
+++ b/Protocols.External/[o] ReportMessageHandler/[a] ReportAbuse.cs
@@ -20,7 +20,7 @@ public class ReportAbuse : ExternalProtocol
 
         var reportId = Guid.NewGuid();
 
-        DiscordHandler.SendReport(reportId.ToString(), category, Player.CharacterName, character, reportMessage);
+        DiscordHandler.SendAbuseReport(reportId.ToString(), category, Player.CharacterName, character, reportMessage);
 
         PlayerContainer.GetPlayerByName(character)?.Character.Reports.TryAdd(reportId.ToString(), new ReportModel
         {

--- a/Protocols.External/[o] ReportMessageHandler/[b] ReportBug.cs
+++ b/Protocols.External/[o] ReportMessageHandler/[b] ReportBug.cs
@@ -1,0 +1,25 @@
+﻿using Server.Reawakened.Core.Services;
+using Server.Reawakened.Network.Protocols;
+using System.Text;
+
+namespace Protocols.External._o__ReportMessageHandler;
+public class ReportBug : ExternalProtocol
+{
+    public override string ProtocolName => "ob";
+
+    public DiscordHandler DiscordHandler { get; set; }
+
+    public override void Run(string[] message)
+    {
+        var detail = Encoding.UTF8.GetString(Convert.FromBase64String(message[5].Replace("detail$", "")));
+        var summary = Encoding.UTF8.GetString(Convert.FromBase64String(message[6].Replace("summary$", "")));
+        // Commented out due to a protocol error
+        //var systeminfo = Encoding.UTF8.GetString(Convert.FromBase64String(message[7].Replace("systemInfo$", "")));
+
+        var reportId = Guid.NewGuid();
+
+        DiscordHandler.SendBugReport(reportId.ToString(), detail, summary, "N/A");
+
+        SendXt("ob", "1");
+    }
+}

--- a/Protocols.External/[s] Synchronizer/[s] State.cs
+++ b/Protocols.External/[s] Synchronizer/[s] State.cs
@@ -4,6 +4,7 @@ using Server.Base.Logging;
 using Server.Base.Timers.Extensions;
 using Server.Base.Timers.Services;
 using Server.Reawakened.Core.Configs;
+using Server.Reawakened.Core.Enums;
 using Server.Reawakened.Entities.Colliders;
 using Server.Reawakened.Entities.Projectiles;
 using Server.Reawakened.Network.Protocols;
@@ -70,6 +71,12 @@ public class State : ExternalProtocol
                     var attack = new ChargeAttack_SyncEvent(syncEvent);
                     var superStompDamage = (int)Math.Ceiling(WorldStatistics.GetValue(ItemEffectType.AbilityPower, WorldStatisticsGroup.Player, Player.Character.GlobalLevel) +
                         WorldStatistics.GlobalStats[Globals.StompDamageBonus]);
+
+                    // Needed because early 2012's ChargeAttack_SyncEvent is different
+                    // without it this causes a vs error
+                    // not fixable in reawakened it would require using the 2012 codebase
+                    if (ServerRConfig.GameVersion <= GameVersion.vPets2012)
+                        return;
 
                     Logger.LogTrace("Super attack is charging: '{Charging}' at ({X}, {Y}) in time: {Delay} " +
                         "at speed ({X}, {Y}) with max pos ({X}, {Y}) for item id: '{Id}' and zone: {Zone}",

--- a/Server.Reawakened/BundleHost/Services/BuildAssetList.cs
+++ b/Server.Reawakened/BundleHost/Services/BuildAssetList.cs
@@ -12,6 +12,7 @@ using Server.Reawakened.BundleHost.Extensions;
 using Server.Reawakened.BundleHost.Helpers;
 using Server.Reawakened.BundleHost.Models;
 using Server.Reawakened.Core.Configs;
+using Server.Reawakened.Core.Enums;
 using Server.Reawakened.Icons.Services;
 using System.Xml;
 
@@ -238,7 +239,9 @@ public class BuildAssetList(ILogger<BuildAssetList> logger, EventSink sink, Asse
 
             // Adding a game version check of vMinigames2012 or deleting this
             // allows early 2012 to load could be a missing cache issue
-            if (asset.Name.StartsWith("NavMesh"))
+            // this requires the 'refreshCacheDir' command to be run each time
+            // you want to go back to other versions bc NavMesh files will not be present
+            if (asset.Name.StartsWith("NavMesh") && sRConfig.GameVersion >= GameVersion.vMinigames2012)
                 asset.Type = AssetInfo.TypeAsset.NavMesh;
             else
             {

--- a/Server.Reawakened/Core/Configs/ServerRConfig.cs
+++ b/Server.Reawakened/Core/Configs/ServerRConfig.cs
@@ -167,7 +167,7 @@ public class ServerRConfig : IRConfig
             { GameVersion.vLate2012, "TNMT_2102_ORP" },
             { GameVersion.vMinigames2012, "regnaRrewoP_2102_ORP" },
             { GameVersion.vPets2012, "regnaRrewoP_2102_ORP" },
-            { GameVersion.vEarly2012, "adnaPuFgnuK_2102_ORP" },
+            { GameVersion.vEarly2012, string.Empty },
             { GameVersion.v2011, string.Empty }
         };
 

--- a/Server.Reawakened/Core/Services/DiscordHandler.cs
+++ b/Server.Reawakened/Core/Services/DiscordHandler.cs
@@ -64,8 +64,8 @@ public class DiscordHandler(DiscordRwConfig rwConfig, PlayerContainer playerCont
         embed.WithTitle("New Report");
         embed.WithDescription(
             "**Report Id:** " + reportId + "\n" +
-            "**Category:** " + detail + "\n" +
-            "**Reporter:** " + summary + "\n"
+            "**Details:** " + detail + "\n" +
+            "**Summary:** " + summary + "\n"
         );
         embed.AddField("System Info:", systemInfo);
 

--- a/Server.Reawakened/Core/Services/DiscordHandler.cs
+++ b/Server.Reawakened/Core/Services/DiscordHandler.cs
@@ -33,7 +33,7 @@ public class DiscordHandler(DiscordRwConfig rwConfig, PlayerContainer playerCont
         socketChannel.SendMessageAsync(author + ": " + message);
     }
 
-    public void SendReport(string reportId, string category, string reporter, string reported, string message)
+    public void SendAbuseReport(string reportId, string category, string reporter, string reported, string message)
     {
         if (_socketClient == null)
             return;
@@ -49,6 +49,25 @@ public class DiscordHandler(DiscordRwConfig rwConfig, PlayerContainer playerCont
             "**Reported:** " + reported + "\n" +
             "**Message:** " + message
         );
+
+        socketChannel.SendMessageAsync(null, false, embed.Build());
+    }
+
+    public void SendBugReport(string reportId, string detail, string summary, string systemInfo)
+    {
+        if (_socketClient == null)
+            return;
+
+        var socketChannel = (ISocketMessageChannel)_socketClient.GetChannel(rwConfig.ReportsChannelId);
+
+        var embed = new EmbedBuilder();
+        embed.WithTitle("New Report");
+        embed.WithDescription(
+            "**Report Id:** " + reportId + "\n" +
+            "**Category:** " + detail + "\n" +
+            "**Reporter:** " + summary + "\n"
+        );
+        embed.AddField("System Info:", systemInfo);
 
         socketChannel.SendMessageAsync(null, false, embed.Build());
     }

--- a/Server.Reawakened/Players/Extensions/PlayerExtensions.cs
+++ b/Server.Reawakened/Players/Extensions/PlayerExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using A2m.Server;
 using Microsoft.Extensions.Logging;
 using Server.Reawakened.Core.Configs;
+using Server.Reawakened.Core.Enums;
 using Server.Reawakened.Database.Characters;
 using Server.Reawakened.Database.Users;
 using Server.Reawakened.Network.Extensions;
@@ -199,7 +200,11 @@ public static class PlayerExtensions
             error = e.Message;
         }
 
-        player.SendXt("lw", error, levelName, surroundingLevels);
+        // Allows early 2012 to load
+        if (worldHandler.Config.GameVersion >= GameVersion.vMinigames2012)
+            player.SendXt("lw", error, levelName, surroundingLevels);
+        else
+            player.SendXt("lw", error, levelName, string.Empty, surroundingLevels);
     }
 
     public static void SetCharacterSelected(this Player player, CharacterModel character)

--- a/Server.Reawakened/Rooms/Services/WorldHandler.cs
+++ b/Server.Reawakened/Rooms/Services/WorldHandler.cs
@@ -22,6 +22,8 @@ public class WorldHandler(EventSink sink, ServerRConfig config, WorldGraph world
     public Dictionary<string, Type> EntityComponents { get; private set; } = [];
     public Dictionary<string, Type> ProcessableComponents { get; private set; } = [];
 
+    public ServerRConfig Config => config;
+
     public void Initialize() => sink.WorldLoad += LoadRooms;
 
     private void LoadRooms()

--- a/Server.Reawakened/XMLs/Bundles/Base/WorldGraph.cs
+++ b/Server.Reawakened/XMLs/Bundles/Base/WorldGraph.cs
@@ -1,4 +1,6 @@
 ﻿using Server.Base.Core.Extensions;
+using Server.Reawakened.Core.Configs;
+using Server.Reawakened.Core.Enums;
 using Server.Reawakened.XMLs.Abstractions.Enums;
 using Server.Reawakened.XMLs.Abstractions.Interfaces;
 using System.Xml;
@@ -14,6 +16,8 @@ public class WorldGraph : WorldGraphXML, IBundledXml
     public int DefaultLevel;
     public int NewbZone;
     public Dictionary<int, List<DestNode>> WorldGraphNodes;
+
+    public ServerRConfig ServerRConfig { get; set; }
 
     public void InitializeVariables()
     {
@@ -32,6 +36,17 @@ public class WorldGraph : WorldGraphXML, IBundledXml
 
     public void EditDescription(XmlDocument xml)
     {
+        if (ServerRConfig.GameVersion <= GameVersion.vPets2012)
+        {
+            var node = xml.SelectNodes("/levels/level[@level_type='MiniGameTrail']");
+
+            foreach (XmlNode level in node)
+            {
+                var parent = level.ParentNode;
+
+                parent.RemoveChild(level);
+            }
+        }
     }
 
     public void ReadDescription(string xml) =>


### PR DESCRIPTION
- Fixed not being able to load into early 2012 due to a bug with the WorldGraph requesting 'MiniGameTrail' levels (early 2012 didn't have minigames)
- Fixed a NavMesh error due to early 2012 not having them (NavMeshes are used for the compass in late 2012 and above only)
- Fixed not being able to load past Forgotten Temple on early 2012 due to missing assets for an EventPopup
- Added the ReportBug protocol

For the early 2012 fixes i've made sure to put GameVersion checks so all versions should continue working