### PR TITLE
Fixes

### DIFF
--- a/Protocols.External/[a] ChatHandler/[e] FreeChat.cs
+++ b/Protocols.External/[a] ChatHandler/[e] FreeChat.cs
@@ -1,5 +1,6 @@
 ﻿using A2m.Server;
 using Microsoft.Extensions.Logging;
+using Server.Base.Accounts.Extensions;
 using Server.Reawakened.Core.Configs;
 using Server.Reawakened.Core.Services;
 using Server.Reawakened.Network.Extensions;
@@ -21,6 +22,12 @@ public class FreeChat : ExternalProtocol
         var channelType = (CannedChatChannel)Convert.ToInt32(message[5]);
         var chatMessage = message[6];
         var recipientName = message[7];
+
+        if (Player.Account.IsMuted())
+        {
+            Player.Chat(CannedChatChannel.Tell, "Console", "You are muted" + Player.Account.FormatMuteTime() + ".");
+            return;
+        }
 
         switch (channelType)
         {

--- a/Protocols.External/[a] ChatHandler/[p] CannedChat.cs
+++ b/Protocols.External/[a] ChatHandler/[p] CannedChat.cs
@@ -1,5 +1,6 @@
 ﻿using A2m.Server;
 using Microsoft.Extensions.Logging;
+using Server.Base.Accounts.Extensions;
 using Server.Reawakened.Core.Configs;
 using Server.Reawakened.Core.Services;
 using Server.Reawakened.Network.Extensions;
@@ -26,6 +27,12 @@ public class CannedChat : ExternalProtocol
         var secondaryPhraseId = int.Parse(message[7]); // named 'specifics' in the client protocol/xml
         var itemId = int.Parse(message[8]);
         var recipientName = message[9];
+
+        if (Player.Account.IsMuted())
+        {
+            Player.Chat(CannedChatChannel.Tell, "Console", "You are muted" + Player.Account.FormatMuteTime() + ".");
+            return;
+        }
 
         var sb = new SeparatedStringBuilder(' ');
 

--- a/Protocols.External/[d] DescriptionHandler/[e] EventInfo.cs
+++ b/Protocols.External/[d] DescriptionHandler/[e] EventInfo.cs
@@ -10,7 +10,7 @@ public class EventInfo : ExternalProtocol
 
     public override void Run(string[] message)
     {
-        if (EventPrefabs.EventInfo != null)
+        if (EventPrefabs.EventInfo != null && Player.TempData.FirstLogin)
             SendXt("de", EventPrefabs.EventInfo.ToString());
     }
 }

--- a/Protocols.External/[f] FriendsHandler/[o] SearchOnlineUsers.cs
+++ b/Protocols.External/[f] FriendsHandler/[o] SearchOnlineUsers.cs
@@ -22,7 +22,7 @@ public class SearchOnlineUsers : ExternalProtocol
         var sb = new SeparatedStringBuilder('|');
 
         foreach (var player in PlayerContainer.GetAllPlayers())
-            if (player.CharacterName.Contains(name) || player.CharacterName.Equals(name))
+            if (player.CharacterName.Contains(name, StringComparison.CurrentCultureIgnoreCase) || player.CharacterName.Equals(name))
                 sb.Append(GetPlayerData(player));
 
         return sb.ToString();

--- a/Protocols.External/[s] Synchronizer/[s] State.cs
+++ b/Protocols.External/[s] Synchronizer/[s] State.cs
@@ -224,6 +224,8 @@ public class State : ExternalProtocol
 
         if (playerTimer.Player.TempData.Invincible)
             playerTimer.Player.TempData.Invincible = false;
+
+        playerTimer.Player.TempData.IsKnockedOut = false;
     }
 
     public void LogEvent(SyncEvent syncEvent, string entityId, Room room)

--- a/Protocols.System/[xml] System/[login] Login.cs
+++ b/Protocols.System/[xml] System/[login] Login.cs
@@ -52,6 +52,16 @@ public class Login : SystemProtocol
             reason = AlrReason.PlayerLoggedIn;
         }
 
-        SendXml("logKO", $"<login e='{reason.GetErrorValue()}' />");
+        var error = reason.GetErrorValue();
+
+        if (reason == AlrReason.Blocked)
+        {
+            var account = AccountHandler.GetAccountFromUsername(username);
+            var banTime = account.FormatBanTime();
+
+            error += banTime;
+        }
+
+        SendXml("logKO", $"<login e='{error}' />");
     }
 }

--- a/Server.Base/Accounts/Extensions/CheckBans.cs
+++ b/Server.Base/Accounts/Extensions/CheckBans.cs
@@ -1,5 +1,6 @@
 ﻿using Server.Base.Core.Extensions;
 using Server.Base.Database.Accounts;
+using System.Text.RegularExpressions;
 using System.Xml;
 
 namespace Server.Base.Accounts.Extensions;
@@ -61,5 +62,59 @@ public static class CheckBans
             banDuration = TimeSpan.Zero;
 
         return banTime != DateTime.MinValue && banDuration != TimeSpan.Zero;
+    }
+
+    public static TimeSpan ParseTime(this AccountModel _, string input)
+    {
+        var m = Regex.Match(input, @"^((?<days>\d+)d)?((?<hours>\d+)h)?((?<minutes>\d+)m)?((?<seconds>\d+)s)?$", RegexOptions.ExplicitCapture | RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.RightToLeft);
+
+        var ds = m.Groups["days"].Success ? int.Parse(m.Groups["days"].Value) : 0;
+        var hs = m.Groups["hours"].Success ? int.Parse(m.Groups["hours"].Value) : 0;
+        var ms = m.Groups["minutes"].Success ? int.Parse(m.Groups["minutes"].Value) : 0;
+        var ss = m.Groups["seconds"].Success ? int.Parse(m.Groups["seconds"].Value) : 0;
+
+        return TimeSpan.FromSeconds(ds * 60 * 60 * 24 + hs * 60 * 60 + ms * 60 + ss);
+    }
+
+    public static string FormatBanTime(this AccountModel account)
+    {
+        var tagTime = account.GetTag("BanTime");
+        var tagDuration = account.GetTag("BanDuration");
+
+        var banTime = tagTime != null ? XmlConverter.GetXmlDateTime(tagTime, DateTime.MinValue) : DateTime.MinValue;
+        TimeSpan banDuration;
+
+        if (tagDuration == "Infinite")
+            banDuration = TimeSpan.MaxValue;
+        else if (tagDuration != null)
+            banDuration = GetTime.ToTimeSpan(tagDuration);
+        else
+            banDuration = TimeSpan.Zero;
+
+        return account.FormatTime(banTime, banDuration);
+    }
+
+    public static string FormatTime(this AccountModel _, DateTime time, TimeSpan duration)
+    {
+        if (duration == TimeSpan.MaxValue)
+            return " permanently";
+
+        var elapsed = DateTime.UtcNow - time;
+        var input = duration - elapsed;
+
+        var output = string.Empty;
+
+        if ((int)input.TotalDays > 0)
+            output += " " + string.Format("{0}d", (int)input.TotalDays);
+
+        if ((int)input.TotalHours > 0)
+            output += " " + string.Format("{0}hr" +
+                (input.Hours == 1 ? string.Empty : "s"), input.Hours);
+
+        if (input.Minutes > 0)
+            output += " " + string.Format("{0}min" +
+                (input.Minutes == 1 ? string.Empty : "s"), input.Minutes);
+
+        return " for" + output;
     }
 }

--- a/Server.Base/Accounts/Extensions/CheckMutes.cs
+++ b/Server.Base/Accounts/Extensions/CheckMutes.cs
@@ -1,0 +1,82 @@
+﻿using Server.Base.Core.Extensions;
+using Server.Base.Database.Accounts;
+using System.Xml;
+
+namespace Server.Base.Accounts.Extensions;
+public static class CheckMutes
+{
+    public static bool IsMuted(this AccountModel account)
+    {
+        var isMuted = account.GetFlag(1);
+
+        if (!isMuted)
+            return false;
+
+        if (!account.GetMuteTags(out var muteTime, out var muteDuration) || muteDuration == TimeSpan.MaxValue ||
+            DateTime.UtcNow < muteTime + muteDuration)
+            return true;
+
+        account.SetUnspecifiedMute(null);
+        account.SetMuted(false);
+        return false;
+    }
+
+    public static void SetMuted(this AccountModel account, bool isMuted) =>
+        account.SetFlag(1, isMuted);
+
+    public static void SetMuteTags(this AccountModel account, string from, DateTime muteTime, TimeSpan muteDuration)
+    {
+        if (from == null)
+            account.RemoveTag("MuteDealer");
+        else
+            account.SetTag("MuteDealer", from);
+
+        if (muteTime == DateTime.MinValue)
+            account.RemoveTag("MuteTime");
+        else
+            account.SetTag("MuteTime", XmlConvert.ToString(muteTime, XmlDateTimeSerializationMode.Utc));
+
+        if (muteDuration == TimeSpan.Zero)
+            account.RemoveTag("MuteDuration");
+        else
+            account.SetTag("MuteDuration", muteDuration.ToString());
+    }
+
+    public static void SetUnspecifiedMute(this AccountModel account, string from) =>
+        account.SetMuteTags(from, DateTime.MinValue, TimeSpan.Zero);
+
+    public static bool GetMuteTags(this AccountModel account, out DateTime muteTime, out TimeSpan muteDuration)
+    {
+        var tagTime = account.GetTag("MuteTime");
+        var tagDuration = account.GetTag("MuteDuration");
+
+        muteTime = tagTime != null ? XmlConverter.GetXmlDateTime(tagTime, DateTime.MinValue) : DateTime.MinValue;
+
+        if (tagDuration == "Infinite")
+            muteDuration = TimeSpan.MaxValue;
+        else if (tagDuration != null)
+            muteDuration = GetTime.ToTimeSpan(tagDuration);
+        else
+            muteDuration = TimeSpan.Zero;
+
+        return muteTime != DateTime.MinValue && muteDuration != TimeSpan.Zero;
+    }
+
+    public static string FormatMuteTime(this AccountModel account)
+    {
+        var tagTime = account.GetTag("MuteTime");
+        var tagDuration = account.GetTag("MuteDuration");
+
+        var muteTime = tagTime != null ? XmlConverter.GetXmlDateTime(tagTime, DateTime.MinValue) : DateTime.MinValue;
+        TimeSpan muteDuration;
+
+        if (tagDuration == "Infinite")
+            muteDuration = TimeSpan.MaxValue;
+        else if (tagDuration != null)
+            muteDuration = GetTime.ToTimeSpan(tagDuration);
+        else
+            muteDuration = TimeSpan.Zero;
+
+        return account.FormatTime(muteTime, muteDuration);
+    }
+}

--- a/Server.Reawakened/Chat/Commands/Misc/FindPlayer.cs
+++ b/Server.Reawakened/Chat/Commands/Misc/FindPlayer.cs
@@ -1,7 +1,8 @@
 ﻿using Server.Base.Accounts.Enums;
+using Server.Base.Database.Accounts;
 using Server.Reawakened.Chat.Models;
+using Server.Reawakened.Database.Characters;
 using Server.Reawakened.Players;
-using Server.Reawakened.Players.Helpers;
 using Server.Reawakened.XMLs.Data.Commands;
 
 namespace Server.Reawakened.Chat.Commands.Misc;
@@ -13,7 +14,7 @@ public class FindPlayer : SlashCommand
 
     public override List<ParameterModel> Parameters =>
     [
-        new ParameterModel() 
+        new ParameterModel()
         {
             Name = "name",
             Description = "Find a player's id by name.",
@@ -24,13 +25,14 @@ public class FindPlayer : SlashCommand
 
     public override AccessLevel AccessLevel => AccessLevel.Moderator;
 
-    public PlayerContainer PlayerContainer { get; set; }
+    public CharacterHandler CharacterHandler { get; set; }
+    public AccountHandler AccountHandler { get; set; }
 
     public override void Execute(Player player, string[] args)
     {
         var name = string.Join(" ", args.Skip(1));
 
-        var target = PlayerContainer.GetPlayerByName(name);
+        var target = CharacterHandler.GetCharacterFromName(name);
 
         if (target == null)
         {
@@ -38,6 +40,6 @@ public class FindPlayer : SlashCommand
             return;
         }
 
-        Log($"{target.CharacterName}'s id is {target.Account.Id}", player);
+        Log($"{target.CharacterName}'s id is {target.UserUuid}", player);
     }
 }

--- a/Server.Reawakened/Chat/Commands/Moderation/Warn.cs
+++ b/Server.Reawakened/Chat/Commands/Moderation/Warn.cs
@@ -17,8 +17,8 @@ public class Warn : SlashCommand
     [
         new ParameterModel()
         {
-            Name = "playerId",
-            Description = "The player character id",
+            Name = "accountId",
+            Description = "The player account id",
             Optional = false
         }
     ];
@@ -31,13 +31,13 @@ public class Warn : SlashCommand
     {
         if (!int.TryParse(args[1], out var id))
         {
-            Log("Invalid player id provided.", player);
+            Log("Invalid player account id provided.", player);
             return;
         }
 
-        var target = PlayerContainer.GetPlayerByAccountId(id);
+        var online = PlayerContainer.GetPlayerByAccountId(id);
 
-        if (target == null)
+        if (online == null)
         {
             Log("The provided player account is null.", player);
             return;
@@ -48,8 +48,8 @@ public class Warn : SlashCommand
             ["type"] = "WARN"
         };
 
-        target.SendXt("yM", type.ToJson());
+        online.SendXt("yM", type.ToJson());
 
-        Log($"Warned player {target.Account.Username}.", player);
+        Log($"Warned player {online.Account.Username}.", player);
     }
 }

--- a/Server.Reawakened/Entities/Components/Characters/Controllers/Base/Abstractions/BaseAIStateMachine.cs
+++ b/Server.Reawakened/Entities/Components/Characters/Controllers/Base/Abstractions/BaseAIStateMachine.cs
@@ -130,6 +130,9 @@ public abstract class BaseAIStateMachine<T> : Component<T>, IAIStateMachine
 
     public override void Update()
     {
+        if (Room == null)
+            return;
+
         foreach (var state in CurrentStates)
             state.UpdateState();
     }

--- a/Server.Reawakened/Entities/Components/GameObjects/Hazards/Abstractions/BaseHazardControllerComp.cs
+++ b/Server.Reawakened/Entities/Components/GameObjects/Hazards/Abstractions/BaseHazardControllerComp.cs
@@ -67,6 +67,10 @@ public abstract class BaseHazardControllerComp<T> : Component<T> where T : Hazar
             {
                 EffectType = ItemEffectType.PoisonDamage;
             }
+            else if (PrefabName.Contains("Deathplane"))
+            {
+                EffectType = ItemEffectType.BluntDamage;
+            }
             else
             {
                 switch (HurtEffect)
@@ -171,6 +175,9 @@ public abstract class BaseHazardControllerComp<T> : Component<T> where T : Hazar
                      player.Character.CalculateDefense(EffectType, ItemCatalog);
 
         Logger.LogTrace("Applying {statusEffect} to {characterName} from {prefabName}", EffectType, player.CharacterName, PrefabName);
+
+        if (PrefabName.Contains("Deathplane"))
+            Damage = 99999;
 
         switch (EffectType)
         {

--- a/Server.Reawakened/Entities/Components/GameObjects/Items/ChestControllerComp.cs
+++ b/Server.Reawakened/Entities/Components/GameObjects/Items/ChestControllerComp.cs
@@ -56,6 +56,8 @@ public class ChestControllerComp : BaseChestControllerComp<ChestController>
 
         Room.SendSyncEvent(triggerEvent);
         Room.SendSyncEvent(triggerReceiver);
+
+        player.SendUpdatedInventory();
     }
 
     //Temporary for chests without loot tables. Could be used for banana rewards in the future.

--- a/Server.Reawakened/Entities/Components/GameObjects/NPC/NPCControllerComp.cs
+++ b/Server.Reawakened/Entities/Components/GameObjects/NPC/NPCControllerComp.cs
@@ -336,6 +336,22 @@ public class NPCControllerComp : Component<NPCController>
     {
         var questData = QuestCatalog.GetQuestData(questId);
 
+        if (QuestCatalog.QuestLineCatalogs.TryGetValue(questData.QuestLineId, out var questLine))
+        {
+            var giverQuest = GiverQuests.OrderBy(x => x.QuestgGiverName == NpcName && questLine.ShowInJournal);
+            var validatorQuest = ValidatorQuests.OrderBy(x => x.ValidatorName == NpcName && questLine.ShowInJournal);
+
+            if (giverQuest.All(y => player.Character.CompletedQuests.Any(z => y.Id == z))
+                && validatorQuest.All(y => player.Character.CompletedQuests.Any(z => y.Id == z))
+                && !giverQuest.Any(x => player.Character.QuestLog.Any(y => x.Id == y.Id))
+                && !validatorQuest.Any(x => player.Character.QuestLog.Any(y => x.Id == y.Id))
+                && questLine.QuestType != QuestType.Daily)
+            {
+                Logger.LogTrace("[{QuestLineId}] [COMPLETED QUESTLINE] Completed {NpcName}'s questline.", questData.QuestLineId, NpcName);
+                return VendorInfo != null ? VendorInfo.VendorType : NPCStatus.Dialog;
+            }
+        }
+
         if (player.Character.CompletedQuests.Contains(questId))
         {
             Logger.LogTrace("[{QuestName} ({QuestId})] [ALREADY COMPLETED]", questData.Name, questData.Id);
@@ -389,7 +405,7 @@ public class NPCControllerComp : Component<NPCController>
             }
         }
 
-        if (!QuestCatalog.QuestLineCatalogs.TryGetValue(questData.QuestLineId, out var questLine))
+        if (!QuestCatalog.QuestLineCatalogs.TryGetValue(questData.QuestLineId, out questLine))
         {
             Logger.LogTrace("[{QuestName} ({QuestId})] [INVALID QUESTLINE] Quest with line {QuestLineId} could not be found",
                 questData.Name, questData.Id, questData.QuestLineId);
@@ -483,7 +499,7 @@ public class NPCControllerComp : Component<NPCController>
         {
             var matchingQuest = player.Character.QuestLog.FirstOrDefault(q => q.Id == quest.Id);
 
-            if (matchingQuest == null || player.Character.CompletedQuests.Contains(quest.Id))
+            if (matchingQuest == null || player.Character.CompletedQuests.Contains(quest.Id) && QuestCatalog.GetQuestLineData(quest.QuestLineId).QuestType != QuestType.Daily)
                 continue;
 
             if (matchingQuest.QuestStatus != QuestState.TO_BE_VALIDATED)
@@ -495,35 +511,10 @@ public class NPCControllerComp : Component<NPCController>
 
             if (completedQuest != null)
             {
-                var questLine = QuestCatalog.GetQuestLineData(quest.QuestLineId);
-
-                player.Character.QuestLog.Remove(completedQuest);
-
-                if (questLine.QuestType == QuestType.Daily)
-                    player.Character.CurrentQuestDailies.TryAdd(completedQuest.Id.ToString(), new DailiesModel()
-                    {
-                        GameObjectId = completedQuest.Id.ToString(),
-                        LevelId = Room.LevelInfo.LevelId,
-                        TimeOfHarvest = DateTime.Now
-                    });
-                else
-                    player.Character.CompletedQuests.Add(completedQuest.Id);
-
                 foreach (var trigger in Room.GetEntitiesFromType<IQuestTriggered>())
                     trigger.QuestCompleted(quest, player);
 
                 Logger.LogInformation("[{QuestName} ({QuestId})] [QUEST COMPLETED]", quest.Name, quest.Id);
-
-                player.UpdateAllNpcsInLevel();
-
-                if (quest.QuestRewards.Count > 0)
-                    foreach (var item in quest.QuestRewards)
-                    {
-                        var newQuest = QuestCatalog.GetQuestData(item.Key);
-
-                        if (newQuest != null && player.Character.CompletedQuests.Any(x => newQuest.PreviousQuests.Any(y => y.Key == x)))
-                            player.AddQuest(newQuest, QuestItems, ItemCatalog, FileLogger, $"Quest reward from {quest.ValidatorName}", Logger);
-                    }
             }
 
             break;

--- a/Server.Reawakened/Entities/Components/GameObjects/NPC/NPCControllerComp.cs
+++ b/Server.Reawakened/Entities/Components/GameObjects/NPC/NPCControllerComp.cs
@@ -417,7 +417,7 @@ public class NPCControllerComp : Component<NPCController>
                 return NPCStatus.Unknown;
             }
 
-        if (Config.GameVersion < GameVersion.vEarly2013 && questData.Name == "T4IR_00_01" 
+        if (Config.GameVersion < GameVersion.vEarly2014 && questData.Name == "T4IR_00_01" 
             && !player.Character.CompletedQuests.Contains(939))
         {
             Logger.LogTrace("[{QuestName}] ({QuestId}) [SKIPPED QUEST] Not all tribe tutorial quests are completed.", questData.Name, questData.Id);

--- a/Server.Reawakened/Players/Extensions/PetAbilityExtensions.cs
+++ b/Server.Reawakened/Players/Extensions/PetAbilityExtensions.cs
@@ -33,6 +33,9 @@ public static class PetAbilityExtensions
         pet.InCoopSwitchState = false;
         pet.AbilityCooldown = petOwner.Room.Time + pet.AbilityParams.CooldownTime;
 
+        if (petOwner.TempData.IsKnockedOut)
+            return;
+
         petOwner.Room.SendSyncEvent(new PetState_SyncEvent(petOwner.GameObjectId, petOwner.Room.Time,
             PetInformation.StateSyncType.Ability, petOwner.GetSyncParams(pet.AbilityParams)));
 
@@ -72,6 +75,9 @@ public static class PetAbilityExtensions
 
         var player = timer.Player;
 
+        if (player.TempData.IsKnockedOut)
+            return;
+
         if (!player.Character.Pets.TryGetValue(player.GetEquippedPetId(new ServerRConfig()), out var pet))
         {
             player.SendDeactivateState();
@@ -88,6 +94,9 @@ public static class PetAbilityExtensions
             return;
 
         var player = timer.Player;
+
+        if (player.TempData.IsKnockedOut)
+            return;
 
         if (!player.Character.Pets.TryGetValue(player.GetEquippedPetId
             (new ServerRConfig()), out var pet) || !pet.AbilityParams.IsAttackAbility())
@@ -117,6 +126,9 @@ public static class PetAbilityExtensions
 
         var player = timer.Player;
 
+        if (player.TempData.IsKnockedOut)
+            return;
+
         if (!player.Character.Pets.ContainsKey
             (player.GetEquippedPetId(new ServerRConfig())))
         {
@@ -133,6 +145,9 @@ public static class PetAbilityExtensions
             return;
 
         var player = timer.Player;
+
+        if (player.TempData.IsKnockedOut)
+            return;
 
         if (!player.Character.Pets.ContainsKey
             (player.GetEquippedPetId(new ServerRConfig())))

--- a/Server.Reawakened/Players/Extensions/PlayerDamageExtensions.cs
+++ b/Server.Reawakened/Players/Extensions/PlayerDamageExtensions.cs
@@ -84,8 +84,11 @@ public static class PlayerDamageExtensions
 
         player.Character.Write.CurrentLife -= (int)damage;
 
-        if (player.Character.CurrentLife < 0)
+        if (player.Character.CurrentLife < 0 && !player.TempData.IsKnockedOut)
+        {
             player.Character.Write.CurrentLife = 0;
+            KnockoutPlayer(player);
+        }
 
         player.Room.SendSyncEvent(new Health_SyncEvent(player.GameObjectId.ToString(), player.Room.Time,
             player.Character.CurrentLife, player.Character.MaxLife, originId));
@@ -103,5 +106,20 @@ public static class PlayerDamageExtensions
         var damage = Convert.ToSingle(Math.Ceiling(health * percentage));
 
         ApplyCharacterDamage(player, damage, hazardId, duration, serverRConfig, timerThread);
+    }
+
+    public static void KnockoutPlayer(this Player player)
+    {
+        player.TempData.IsSlowed = false;
+        player.TempData.IsSuperStomping = false;
+        player.TempData.Underwater = false;
+        player.TempData.Invincible = true;
+        player.TempData.IsKnockedOut = true;
+
+        if (player.TempData.UnderwaterTimer != null)
+        {
+            player.TempData.UnderwaterTimer.Stop();
+            player.TempData.UnderwaterTimer = null;
+        }
     }
 }

--- a/Server.Reawakened/Players/Extensions/PlayerExtensions.cs
+++ b/Server.Reawakened/Players/Extensions/PlayerExtensions.cs
@@ -454,4 +454,19 @@ public static class PlayerExtensions
         )
             player.SendXt("iq", sentPlayer.UserId, sentPlayer.Character.Equipment);
     }
+
+    public static void SendWarningMessage(this Player player, string code)
+    {
+        code = code switch
+        {
+            "vendor" or "trading" or "gifting" => "523",
+            "chat" => "320",
+            "shutdown" => "514",
+            "mute" => "505",
+            _ => "514",
+        };
+
+        if (int.TryParse(code, out var result))
+            player.SendXt("wm", result);
+    }
 }

--- a/Server.Reawakened/Players/Models/Misc/TemporaryDataModel.cs
+++ b/Server.Reawakened/Players/Models/Misc/TemporaryDataModel.cs
@@ -25,6 +25,7 @@ public class TemporaryDataModel
     public bool IsSuperStomping { get; set; } = false;
     public bool IsSlowed { get; set; } = false;
     public BaseComponent CurrentArena { get; set; } = null;
+    public bool IsKnockedOut { get; set; } = false;
 
     public List<string> CollidingHazards { get; set; } = [];
     public Dictionary<int, bool> VotedForItem { get; set; } = [];


### PR DESCRIPTION
### Fixes
- Fixed Ice Raider questline being given early in the 2013 questline
- Fixed a Room state machine error
- Fixed quest item rewards sometimes being skipped
- Fixed daily quests not resetting
- Added offline support for moderation slash commands
- Added an improved chat mute system
- Fixed inventory not being updated when opening chests
- Added lowercase name support for searching for monkeys in the Social Notebook
- Fixed a softlock caused by Fireswoop's ability activating after death
- Fixed a bug with the death plane not instantly defeating players
- Fixed repeated event popups when going to a new trail
- Readded the dialog npc status upon all of their quests being completed
### New Moderation Command Format:
- /ban <accountid> [time - 1d1h1m1s etc] (time is optional will default to permanent) - Sends an error message to the player if they are online that they have been banned and are kicked from the server
- /mute <accountid> [time - 1d1h1m1s etc] (time is optional will default to permanent) - Mutes the player all chat messages from them will be cancelled
- /warn <accountid> - Sends a warning error message to the player
- /kick <accountid> - Kicks the player from the server
- /unban <accountid> - Unban the player
- /unmute <accountid> - Unmute the player

to find the player account id you can use /findplayer <monkey name> (monkey name is case sensitive it has to be properly capitalized) and it will send a message with their id in chat