### PR TITLE
Quest & Leaderboard Fixes

### DIFF
--- a/Server.Reawakened/Assets/LocalAssets/InternalEnemyData.xml
+++ b/Server.Reawakened/Assets/LocalAssets/InternalEnemyData.xml
@@ -2573,44 +2573,6 @@
                 </LootTable>
             </Enemy>
         </EnemyCategory>
-        <EnemyCategory name="SpngBob">
-            <Enemy name="PF_Spite_MiniRoboPlankton01">
-                <LootTable>
-                </LootTable>
-            </Enemy>
-            <Enemy name="PF_Spite_MiniRoboPlankton02">
-                <LootTable>
-                </LootTable>
-            </Enemy>
-        </EnemyCategory>
-        <EnemyCategory name="TMNT">
-            <Enemy name="PF_Spite_TMNT_FootJumper01">
-                <LootTable>
-                </LootTable>
-            </Enemy>
-            <Enemy name="PF_Spite_TMNT_FootPatroller01">
-                <LootTable>
-                </LootTable>
-            </Enemy>
-            <Enemy name="PF_Spite_TMNT_FootThrower01">
-                <LootTable>
-                </LootTable>
-            </Enemy>
-        </EnemyCategory>
-        <EnemyCategory name="PwrRngr">
-            <Enemy name="PF_Spite_PR_XborgBoss01">
-                <LootTable>
-                </LootTable>
-            </Enemy>
-            <Enemy name="PF_Spite_PR_XborgPatroller01">
-                <LootTable>
-                </LootTable>
-            </Enemy>
-            <Enemy name="PF_Spite_PR_XborgShooter01">
-                <LootTable>
-                </LootTable>
-            </Enemy>
-        </EnemyCategory>
     </AiType>
     <AiType name="State">
         <EnemyCategory name="Spiderling">
@@ -2696,10 +2658,44 @@
                 <LootTable>
                 </LootTable>
             </Enemy>
+            <Enemy name="PF_Spite_MiniRoboPlankton01">
+                <LootTable>
+                </LootTable>
+            </Enemy>
+            <Enemy name="PF_Spite_MiniRoboPlankton02">
+                <LootTable>
+                </LootTable>
+            </Enemy>
         </EnemyCategory>
         <EnemyCategory name="TMNT">
             <!-- Uses SPIDERLING AI State Controller -->
             <Enemy name="PF_Spite_TMNT_Shredder01">
+                <LootTable>
+                </LootTable>
+            </Enemy>
+            <Enemy name="PF_Spite_TMNT_FootJumper01">
+                <LootTable>
+                </LootTable>
+            </Enemy>
+            <Enemy name="PF_Spite_TMNT_FootPatroller01">
+                <LootTable>
+                </LootTable>
+            </Enemy>
+            <Enemy name="PF_Spite_TMNT_FootThrower01">
+                <LootTable>
+                </LootTable>
+            </Enemy>
+        </EnemyCategory>
+        <EnemyCategory name="PwrRngr">
+            <Enemy name="PF_Spite_PR_XborgBoss01">
+                <LootTable>
+                </LootTable>
+            </Enemy>
+            <Enemy name="PF_Spite_PR_XborgPatroller01">
+                <LootTable>
+                </LootTable>
+            </Enemy>
+            <Enemy name="PF_Spite_PR_XborgShooter01">
                 <LootTable>
                 </LootTable>
             </Enemy>

--- a/Server.Reawakened/Players/Extensions/CharacterInventoryExtensions.cs
+++ b/Server.Reawakened/Players/Extensions/CharacterInventoryExtensions.cs
@@ -117,7 +117,7 @@ public static class CharacterInventoryExtensions
             return;
 
         var characterData = player.Character;
-        var itemCount = 0;
+        var itemCount = count;
 
         if (!characterData.Inventory.Items.ContainsKey(item.ItemId))
             characterData.Inventory.Items.Add(item.ItemId, new ItemModel(item.ItemId, count, item.BindingCount, item.DelayUseExpiry));

--- a/Web.Apps/Leaderboards/API/Scores/TopScoresController.cs
+++ b/Web.Apps/Leaderboards/API/Scores/TopScoresController.cs
@@ -10,7 +10,7 @@ using Web.Apps.Leaderboards.Database.Scores;
 using Web.Apps.Leaderboards.Services;
 
 namespace Web.Apps.Leaderboards.API.Scores;
-[Route("leaderboards/api/top/scores/{gameId}")]
+[Route("Apps/leaderboards/api/top/scores/{gameId}")]
 public class TopScoresController(CharacterHandler characterHandler, TopScoresHandler topScoresHandler,
     InternalLeaderboards leaderboards, ServerRConfig rConfig, LeaderboardHandler leaderboardHandler) : Controller
 {

--- a/Web.Apps/Leaderboards/API/Scores/TopScoresController.cs
+++ b/Web.Apps/Leaderboards/API/Scores/TopScoresController.cs
@@ -1,18 +1,16 @@
 ﻿using LitJson;
 using Microsoft.AspNetCore.Mvc;
-using Server.Base.Core.Extensions;
-using Server.Reawakened.Core.Configs;
-using Server.Reawakened.Core.Enums;
 using Server.Reawakened.Database.Characters;
 using Server.Reawakened.XMLs.Bundles.Internal;
 using System.Globalization;
 using Web.Apps.Leaderboards.Data;
 using Web.Apps.Leaderboards.Database.Scores;
+using Web.Apps.Leaderboards.Services;
 
 namespace Web.Apps.Leaderboards.API.Scores;
-[Route("Apps/leaderboards/api/top/scores/{gameId}")]
+[Route("leaderboards/api/top/scores/{gameId}")]
 public class TopScoresController(CharacterHandler characterHandler, TopScoresHandler topScoresHandler,
-    InternalLeaderboards leaderboards, ServerRConfig rConfig) : Controller
+    InternalLeaderboards leaderboards, LeaderboardHandler leaderboardHandler) : Controller
 {
     [HttpGet]
     public IActionResult GetScores([FromRoute] string gameId)
@@ -51,45 +49,57 @@ public class TopScoresController(CharacterHandler characterHandler, TopScoresHan
             topScoresObject["game"]["ranked"] = game.ranked;
 
         var topScores = topScoresHandler.GetScoresFromId(_gameId);
-        
-        var allScores = new List<TopScore>();
-        var dailyScores = new List<TopScore>();
-        var weeklyScores = new List<TopScore>();
 
-        if (topScores != null)
+        if (topScores != null && topScores.Scores != null)
         {
-            var topScoresList = topScores.Scores.DeepCopy();
-            var sortedScores = SortScores(game, topScoresList);
+            var sortedScores = SortScores(game, topScores.Scores);
 
-            var hasChanges = false;
+            var now = DateTime.Now;
+            var currentYear = now.Year;
+            var currentDate = now.Date;
+            var currentWeek = ISOWeek.GetWeekOfYear(now);
+
+            var seenCharacters = new HashSet<int>();
+            var allTimeChars = new HashSet<int>();
+            var weeklyChars = new HashSet<int>();
+            var dailyChars = new HashSet<int>();
+            
+            var characterCache = leaderboardHandler.CharacterCache; 
+            var invalidCharacters = new HashSet<int>();
 
             var allRank = 1;
             var weeklyRank = 1;
             var dailyRank = 1;
+
             foreach (var score in sortedScores)
             {
-                var character = characterHandler.GetCharacterFromId(score.CharacterId);
+                if (!characterCache.TryGetValue(score.CharacterId, out var character))
+                {
+                    character = characterHandler.GetCharacterFromId(score.CharacterId);
+                    characterCache[score.CharacterId] = character;
+                }
 
                 if (character == null)
                 {
-                    topScores.Scores.Remove(score);
-                    hasChanges = true;
+                    characterCache.Remove(score.CharacterId);
+                    invalidCharacters.Add(score.CharacterId);
                     continue;
                 }
-                
-                var charJson = new JsonData
-                {
-                    ["id"] = character.Id,
-                    ["name"] = character.CharacterName,
-                    ["gender"] = (short)character.Gender,
-                    ["level"] = (short)character.GlobalLevel,
-                    ["tribe"] = Enum.GetName(character.Allegiance)
-                };
 
-                if (allScores.All(x => x.CharacterId != character.Id)
-                    && dailyScores.All(x => x.CharacterId != character.Id)
-                    && weeklyScores.All(x => x.CharacterId != character.Id))
+                if (seenCharacters.Add(character.Id))
+                {
+                    var charJson = new JsonData
+                    {
+                        ["id"] = character.Id,
+                        ["name"] = character.CharacterName,
+                        ["gender"] = (short)character.Gender,
+                        ["level"] = (short)character.GlobalLevel,
+                        ["tribe"] = Enum.GetName(character.Allegiance),
+                    };
                     topScoresObject["characters"].Add(charJson);
+                }
+
+                var dateTime = DateTime.ParseExact(score.Time, "yyyy'-'MM'-'dd'T'HH':'mm':'sszzz", null);
                 
                 var scoreJson = new JsonData
                 {
@@ -99,43 +109,35 @@ public class TopScoresController(CharacterHandler characterHandler, TopScoresHan
                     ["time"] = score.Time
                 };
 
-                if (allScores.All(x => x.CharacterId != score.CharacterId))
+                if (allTimeChars.Add(score.CharacterId))
                 {
-                    scoreJson["rank"] = allRank;
+                    scoreJson["rank"] = allRank++;
                     topScoresObject["scores"]["alltime"].Add(scoreJson);
-                    allRank++;
-                    allScores.Add(score);
-                    continue;
-                }
-                
-                var dateTime = DateTime.ParseExact(score.Time, "yyyy'-'MM'-'dd'T'HH':'mm':'sszzz", null);
-
-                var timeDiff = dateTime - DateTime.Now;
-
-                if (weeklyScores.All(x => x.CharacterId != score.CharacterId)
-                    && ISOWeek.GetWeekOfYear(dateTime) == ISOWeek.GetWeekOfYear(DateTime.Now)
-                    && dateTime.Year == DateTime.Now.Year)
-                {
-                    scoreJson["rank"] = weeklyRank;
-                    topScoresObject["scores"]["week"].Add(scoreJson);
-                    weeklyRank++;
-                    weeklyScores.Add(score);
                     continue;
                 }
 
-                if (dailyScores.All(x => x.CharacterId != score.CharacterId)
-                    && dateTime.Date == DateTime.Now.Date)
-                {
-                    scoreJson["rank"] = dailyRank;
-                    topScoresObject["scores"]["day"].Add(scoreJson);
-                    dailyRank++;
-                    dailyScores.Add(score);
-                    continue;
-                }
+                if (dateTime.Year == currentYear && ISOWeek.GetWeekOfYear(dateTime) == currentWeek)
+                    if (weeklyChars.Add(score.CharacterId))
+                    {
+                        scoreJson["rank"] = weeklyRank++;
+                        topScoresObject["scores"]["week"].Add(scoreJson);
+                        continue;
+                    }
+
+                if (dateTime.Date == currentDate)
+                    if (dailyChars.Add(score.CharacterId))
+                    {
+                        scoreJson["rank"] = dailyRank++;
+                        topScoresObject["scores"]["day"].Add(scoreJson);
+                        continue;
+                    }
             }
 
-            if (hasChanges)
+            if (invalidCharacters.Count > 0)
+            {
+                topScores.Scores.RemoveAll(x => invalidCharacters.Contains(x.CharacterId));
                 topScoresHandler.Update(topScores.Write);
+            }
         }
 
         return Ok(JsonMapper.ToJson(topScoresObject));

--- a/Web.Apps/Leaderboards/API/Scores/TopScoresController.cs
+++ b/Web.Apps/Leaderboards/API/Scores/TopScoresController.cs
@@ -1,5 +1,7 @@
 ﻿using LitJson;
 using Microsoft.AspNetCore.Mvc;
+using Server.Reawakened.Core.Configs;
+using Server.Reawakened.Core.Enums;
 using Server.Reawakened.Database.Characters;
 using Server.Reawakened.XMLs.Bundles.Internal;
 using System.Globalization;
@@ -10,7 +12,7 @@ using Web.Apps.Leaderboards.Services;
 namespace Web.Apps.Leaderboards.API.Scores;
 [Route("leaderboards/api/top/scores/{gameId}")]
 public class TopScoresController(CharacterHandler characterHandler, TopScoresHandler topScoresHandler,
-    InternalLeaderboards leaderboards, LeaderboardHandler leaderboardHandler) : Controller
+    InternalLeaderboards leaderboards, ServerRConfig rConfig, LeaderboardHandler leaderboardHandler) : Controller
 {
     [HttpGet]
     public IActionResult GetScores([FromRoute] string gameId)

--- a/Web.Apps/Leaderboards/Services/LeaderboardHandler.cs
+++ b/Web.Apps/Leaderboards/Services/LeaderboardHandler.cs
@@ -1,6 +1,6 @@
-﻿using LitJson;
-using Server.Base.Core.Abstractions;
+﻿using Server.Base.Core.Abstractions;
 using Server.Base.Core.Events;
+using Server.Reawakened.Database.Characters;
 using Server.Reawakened.XMLs.Bundles.Internal;
 
 namespace Web.Apps.Leaderboards.Services;
@@ -9,12 +9,18 @@ public class LeaderboardHandler(EventSink sink, InternalLeaderboards leaderboard
 {
     public LeaderBoardGameJson Games { get; private set; }
 
+    public Dictionary<int, CharacterModel> CharacterCache;
+
     public void Initialize() => sink.WorldLoad += LoadLeaderboard;
 
-    private void LoadLeaderboard() =>
+    private void LoadLeaderboard()
+    {
         Games = new LeaderBoardGameJson
         {
             status = true,
             games = [.. leaderboards.Games]
         };
+        
+        CharacterCache = [];
+    }
 }


### PR DESCRIPTION
- Fixed "GEARING UP" quest failing due to a bug with the inventory check quest objective
- Fixed enemy data errors about event enemies being in the wrong enemy category (moved them into ai state)
- Added caching to leaderboards to prevent long loading times